### PR TITLE
Upgrade Testing Gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,43 +3,43 @@ GEM
   specs:
     CFPropertyList (2.2.8)
     diff-lcs (1.2.5)
-    facter (2.3.0)
+    facter (2.4.1)
       CFPropertyList (~> 2.2.6)
     hiera (1.3.4)
       json_pure
-    json_pure (1.8.1)
+    json_pure (1.8.2)
     metaclass (0.0.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    puppet (3.7.3)
+    puppet (3.7.4)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
     puppet-lint (1.1.0)
-    puppet-syntax (1.4.0)
+    puppet-syntax (2.0.0)
       rake
-    puppetlabs_spec_helper (0.8.2)
+    puppetlabs_spec_helper (0.10.1)
       mocha
       puppet-lint
       puppet-syntax
       rake
-      rspec
       rspec-puppet
     rake (10.4.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.2)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-puppet (1.0.1)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-puppet (2.0.1)
       rspec
-    rspec-support (3.1.2)
+    rspec-support (3.2.2)
 
 PLATFORMS
   ruby

--- a/Rakefile
+++ b/Rakefile
@@ -24,14 +24,3 @@ task :unit do
    Rake::Task["spec"].invoke
    Rake::Task["lint"].invoke
 end
-
-## Issues
-#
-# Rspec-Puppet currently does not support Rspec 3 so you will see this:
-#
-# RSpec::Puppet::ManifestMatchers::CreateGeneric implements a legacy RSpec
-# matcher protocol. For the current protocol you should expose the failure
-# messages via the `failure_message` and `failure_message_when_negated` methods.
-#
-# Once [Rspec-Puppet Issue](https://github.com/rodjek/rspec-puppet/pull/204)
-# has been merged in, upgrade rspec-puppet and get rid of the deprecation warnings.


### PR DESCRIPTION
Upgrade testing gems. Rspec-Puppet no longer throws deprecation
warnings during rspec.
